### PR TITLE
Avoid emacs magic comment in elisp header

### DIFF
--- a/el2markdown.el
+++ b/el2markdown.el
@@ -238,7 +238,7 @@
 
 
 (defun el2markdown-convert-title ()
-  (when (looking-at ";;+ \\(.*\\)\\.el --+ \\(.*\\)$")
+  (when (looking-at ";;+ \\(.*\\)\\.el --+ \\(.*?\\)\\(-\\*-.*-\\*-\\)?$")
     (el2markdown-emit-header 1 (concat (match-string-no-properties 1)
                                        " - "
                                        (match-string-no-properties 2)))


### PR DESCRIPTION
When grabbing the package title / description.  Avoid getting the emacs magic comment (ie. lexical binding etc.) if it's in the top row.
